### PR TITLE
Add validate action to secrets command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Add [site-config](https://github.com/homestak-dev/site-config) to core modules
-- Add `secrets` CLI command for site-config management (decrypt, encrypt, check)
+- Add `secrets` CLI command for site-config management (decrypt, encrypt, check, validate)
 
 ### Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ After running install.sh:
 # Commands
 homestak playbook <name> [args]    # Run ansible playbook
 homestak scenario <name> [args]    # Run iac-driver scenario
-homestak secrets <action>          # Manage secrets (decrypt, encrypt, check)
+homestak secrets <action>          # Manage secrets (decrypt, encrypt, check, validate)
 homestak install <module>          # Install optional module (packer)
 homestak update                    # Update all repositories
 homestak status                    # Show installation status

--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,7 @@ usage() {
     echo "Commands:"
     echo "  playbook <name> [args]    Run an ansible playbook"
     echo "  scenario <name> [args]    Run an iac-driver scenario"
-    echo "  secrets <action>          Manage secrets (decrypt, encrypt, check)"
+    echo "  secrets <action>          Manage secrets (decrypt, encrypt, check, validate)"
     echo "  install <module>          Install optional module (packer)"
     echo "  update                    Update all repositories"
     echo "  status                    Show installation status"
@@ -247,13 +247,13 @@ manage_secrets() {
     fi
 
     case "$action" in
-        decrypt|encrypt|check)
+        decrypt|encrypt|check|validate)
             echo -e "${GREEN}==>${NC} Running: make $action"
             make -C "$site_config" "$action"
             ;;
         *)
             echo -e "${RED}Unknown action: $action${NC}"
-            echo "Available actions: decrypt, encrypt, check"
+            echo "Available actions: decrypt, encrypt, check, validate"
             exit 1
             ;;
     esac
@@ -311,7 +311,7 @@ case "$CMD" in
         run_scenario "$@"
         ;;
     secrets)
-        [[ $# -lt 1 ]] && { echo "Usage: homestak secrets <decrypt|encrypt|check>"; exit 1; }
+        [[ $# -lt 1 ]] && { echo "Usage: homestak secrets <decrypt|encrypt|check|validate>"; exit 1; }
         manage_secrets "$1"
         ;;
     install)


### PR DESCRIPTION
## Summary

Update secrets management to include the validate action for YAML syntax validation, matching the new site-config Makefile.

## Changes

- Add `validate` to the secrets command actions
- Update documentation to reflect new action

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)