### PR TITLE
docs: Update pve-configure → pve-setup scenario name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ curl -fsSL .../install.sh | HOMESTAK_USER=homestak bash
 homestak status
 homestak pve-setup
 homestak playbook user -e local_user=myuser
-homestak scenario pve-configure --local
+homestak scenario pve-setup --local
 ```
 
 ## What It Does

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ homestak pve-setup
 homestak playbook user -e local_user=myuser
 
 # Run a scenario
-homestak scenario pve-configure --local
+homestak scenario pve-setup --local
 
 # Change network settings
 homestak network -e pve_network_tasks='["static"]' -e pve_new_ip=10.0.12.100

--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,7 @@ usage() {
     echo "Examples:"
     echo "  homestak pve-setup"
     echo "  homestak playbook user -e local_user=myuser"
-    echo "  homestak scenario pve-configure --local"
+    echo "  homestak scenario pve-setup --local"
     echo "  homestak secrets decrypt"
     echo "  homestak install packer"
     echo ""


### PR DESCRIPTION
## Summary

Update documentation to reflect iac-driver scenario rename from `pve-configure` to `pve-setup` (iac-driver#57).

## Changes
- `install.sh`: Update example in usage help
- `CLAUDE.md`: Update quick reference example
- `README.md`: Update usage example

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)