### PR TITLE
feat: Add site-init and images commands to homestak CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Add `homestak site-init` command for site configuration initialization (#10)
+  - Generates host config via `make host-config`
+  - Generates node config if PVE is installed
+  - Creates SSH key (ed25519) if missing
+  - Decrypts secrets if encrypted file exists
+  - Supports `--force` to overwrite existing configs
+- Add `homestak images` command for packer image management (#11)
+  - `images list [--version <tag>]` - list available images from GitHub release
+  - `images download <targets...> [--version <tag>] [--overwrite] [--publish]` - download images
+  - `images publish [<targets...>] [--overwrite]` - install images to PVE storage
+  - Downloads to `/var/tmp/homestak/images/` for persistence
+  - Supports split file reassembly for large images
+  - Graceful resume with curl `-C -` for interrupted downloads
+
 ## v0.18 - 2026-01-13
 
 - Release alignment with homestak v0.18

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ After running install.sh:
 
 ```bash
 # Commands
+homestak site-init [--force]       # Initialize site configuration
+homestak images <subcommand>       # Manage packer images
 homestak playbook <name> [args]    # Run ansible playbook
 homestak scenario <name> [args]    # Run iac-driver scenario
 homestak secrets <action>          # Manage secrets (decrypt, encrypt, check, validate)
@@ -65,11 +67,40 @@ homestak install <module>          # Install optional module (packer)
 homestak update                    # Update all repositories
 homestak status                    # Show installation status
 
+# Image subcommands
+homestak images list [--version <tag>]
+homestak images download <target...> [--version <tag>] [--overwrite] [--publish]
+homestak images publish [<target...>] [--overwrite]
+
 # Playbook shortcuts
 homestak pve-setup                 # Configure Proxmox host
 homestak pve-install               # Install PVE on Debian 13
 homestak user                      # User management
 homestak network                   # Network configuration
+```
+
+### Site Initialization
+
+The `site-init` command prepares a fresh system for homestak workflows:
+
+1. Generates `hosts/<hostname>.yaml` from system info
+2. Generates `nodes/<hostname>.yaml` if PVE is installed
+3. Creates SSH key (ed25519) if none exists
+4. Decrypts secrets if encrypted file exists
+
+### Image Management
+
+The `images` command manages packer images from GitHub releases:
+
+- **Download location**: `/var/tmp/homestak/images/` (persists across reboots)
+- **Publish location**: `/var/lib/vz/template/iso/` (PVE storage)
+- **Split files**: Automatically reassembles `*.partaa`, `*.partab`, etc.
+- **Resume support**: Uses `curl -C -` for interrupted downloads
+
+Typical workflow:
+```bash
+homestak images download all --publish   # Download and install all images
+homestak images list --version v0.22     # List images in specific release
 ```
 
 ## Environment Variables

--- a/install.sh
+++ b/install.sh
@@ -139,12 +139,19 @@ usage() {
     echo "Usage: homestak <command> [options]"
     echo ""
     echo "Commands:"
+    echo "  site-init [--force]       Initialize site configuration"
+    echo "  images <subcommand>       Manage packer images"
     echo "  playbook <name> [args]    Run an ansible playbook"
     echo "  scenario <name> [args]    Run an iac-driver scenario"
     echo "  secrets <action>          Manage secrets (decrypt, encrypt, check, validate)"
     echo "  install <module>          Install optional module (packer)"
     echo "  update                    Update all repositories"
     echo "  status                    Show installation status"
+    echo ""
+    echo "Image subcommands:"
+    echo "  images list [--version <tag>]"
+    echo "  images download <target...> [--version <tag>] [--overwrite] [--publish]"
+    echo "  images publish [<target...>] [--overwrite]"
     echo ""
     echo "Playbook shortcuts:"
     echo "  pve-setup                 Configure Proxmox host"
@@ -153,6 +160,8 @@ usage() {
     echo "  network                   Network configuration"
     echo ""
     echo "Examples:"
+    echo "  homestak site-init"
+    echo "  homestak images download all --publish"
     echo "  homestak pve-setup"
     echo "  homestak playbook user -e local_user=myuser"
     echo "  homestak scenario pve-setup --local"
@@ -295,6 +304,343 @@ show_status() {
     echo ""
 }
 
+site_init() {
+    local force=false
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force) force=true; shift ;;
+            *) echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+        esac
+    done
+
+    local site_config="$HOMESTAK_DIR/site-config"
+    if [[ ! -d "$site_config" ]]; then
+        echo -e "${RED}site-config not found. Run bootstrap first.${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}==>${NC} Site initialization"
+
+    # Step 1: Generate host configuration
+    local host_config="$site_config/hosts/$(hostname).yaml"
+    if [[ -f "$host_config" && "$force" != "true" ]]; then
+        echo -e "${RED}Host config already exists: $host_config${NC}"
+        echo "Use --force to overwrite"
+        exit 1
+    fi
+    echo "  Generating host configuration..."
+    if [[ "$force" == "true" ]]; then
+        make -C "$site_config" host-config FORCE=1 2>&1 | sed 's/^/    /'
+    else
+        make -C "$site_config" host-config 2>&1 | sed 's/^/    /'
+    fi
+
+    # Step 2: Generate node configuration (if PVE is installed)
+    if command -v pvesh &>/dev/null; then
+        local node_config="$site_config/nodes/$(hostname).yaml"
+        if [[ -f "$node_config" && "$force" != "true" ]]; then
+            echo -e "${RED}Node config already exists: $node_config${NC}"
+            echo "Use --force to overwrite"
+            exit 1
+        fi
+        echo "  Generating node configuration (PVE detected)..."
+        if [[ "$force" == "true" ]]; then
+            make -C "$site_config" node-config FORCE=1 2>&1 | sed 's/^/    /'
+        else
+            make -C "$site_config" node-config 2>&1 | sed 's/^/    /'
+        fi
+    else
+        echo "  Skipping node config (PVE not detected)"
+    fi
+
+    # Step 3: Check/generate SSH key
+    local ssh_key="$HOME/.ssh/id_ed25519"
+    local ssh_pub="$HOME/.ssh/id_ed25519.pub"
+    if [[ ! -f "$ssh_pub" ]]; then
+        echo "  Generating SSH key (ed25519)..."
+        ssh-keygen -t ed25519 -f "$ssh_key" -N "" -C "$(whoami)@$(hostname)"
+        echo "  Created: $ssh_pub"
+    else
+        echo "  SSH key exists: $ssh_pub"
+    fi
+
+    # Step 4: Decrypt secrets if encrypted file exists
+    if [[ -f "$site_config/secrets.yaml.enc" ]]; then
+        if [[ -f "$site_config/secrets.yaml" ]]; then
+            echo "  Secrets already decrypted"
+        else
+            echo "  Decrypting secrets..."
+            make -C "$site_config" decrypt 2>&1 | sed 's/^/    /' || {
+                echo -e "${YELLOW}  Warning: Could not decrypt secrets (age key may be missing)${NC}"
+            }
+        fi
+    else
+        echo "  No encrypted secrets found"
+    fi
+
+    echo ""
+    echo -e "${GREEN}==>${NC} Site initialization complete"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Review generated configs in $site_config/"
+    echo "  2. Add your SSH public key to secrets.yaml"
+    echo "  3. Run: homestak images download all --publish"
+    echo ""
+}
+
+# Images directory
+IMAGES_DIR="/var/tmp/homestak/images"
+PVE_ISO_DIR="/var/lib/vz/template/iso"
+
+images_list() {
+    local version="latest"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --version) version="$2"; shift 2 ;;
+            *) echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+        esac
+    done
+
+    echo -e "${GREEN}==>${NC} Available images (release: $version)"
+    echo ""
+
+    local assets
+    assets=$(gh release view "$version" --repo "homestak-dev/packer" --json assets --jq '.assets[].name' 2>/dev/null)
+
+    if [[ -z "$assets" ]]; then
+        echo "No images found in release '$version'"
+        exit 1
+    fi
+
+    # Filter to only .qcow2 files (not checksums or parts)
+    local images
+    images=$(echo "$assets" | grep '\.qcow2$' || true)
+
+    if [[ -z "$images" ]]; then
+        # Check for split files
+        images=$(echo "$assets" | grep '\.qcow2\.partaa$' | sed 's/\.partaa$//' || true)
+    fi
+
+    if [[ -z "$images" ]]; then
+        echo "No images found in release '$version'"
+        exit 1
+    fi
+
+    echo "Images:"
+    echo "$images" | while read -r img; do
+        local size=""
+        # Check if split
+        if echo "$assets" | grep -q "^${img}\.partaa$"; then
+            local parts
+            parts=$(echo "$assets" | grep "^${img}\.part" | wc -l)
+            echo "  $img (split: $parts parts)"
+        else
+            echo "  $img"
+        fi
+    done
+    echo ""
+}
+
+images_download() {
+    local version="latest"
+    local overwrite=false
+    local publish=false
+    local targets=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --version) version="$2"; shift 2 ;;
+            --overwrite) overwrite=true; shift ;;
+            --publish) publish=true; shift ;;
+            -*) echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+            *) targets+=("$1"); shift ;;
+        esac
+    done
+
+    if [[ ${#targets[@]} -eq 0 ]]; then
+        echo "Usage: homestak images download <target...> [--version <tag>] [--overwrite] [--publish]"
+        echo ""
+        echo "Targets: all, debian-12-custom, debian-13-custom, debian-13-pve, or any .qcow2 filename"
+        exit 1
+    fi
+
+    mkdir -p "$IMAGES_DIR"
+
+    echo -e "${GREEN}==>${NC} Downloading images (release: $version)"
+
+    # Get list of available assets
+    local assets
+    assets=$(gh release view "$version" --repo "homestak-dev/packer" --json assets --jq '.assets[].name' 2>/dev/null)
+
+    if [[ -z "$assets" ]]; then
+        echo -e "${RED}No release found: $version${NC}"
+        exit 1
+    fi
+
+    # Expand "all" target
+    if [[ " ${targets[*]} " =~ " all " ]]; then
+        targets=($(echo "$assets" | grep '\.qcow2$' || true))
+        # Also get split file bases
+        local split_bases
+        split_bases=$(echo "$assets" | grep '\.qcow2\.partaa$' | sed 's/\.partaa$//' || true)
+        if [[ -n "$split_bases" ]]; then
+            while read -r base; do
+                targets+=("$base")
+            done <<< "$split_bases"
+        fi
+    fi
+
+    for target in "${targets[@]}"; do
+        # Normalize target name (add .qcow2 if missing)
+        if [[ ! "$target" =~ \.qcow2$ ]]; then
+            target="${target}.qcow2"
+        fi
+
+        local output_file="$IMAGES_DIR/$target"
+
+        # Check if exists
+        if [[ -f "$output_file" && "$overwrite" != "true" ]]; then
+            echo -e "${RED}File exists: $output_file${NC}"
+            echo "Use --overwrite to replace"
+            continue
+        fi
+
+        # Check if this is a split file
+        if echo "$assets" | grep -q "^${target}\.partaa$"; then
+            echo "  Downloading $target (split file)..."
+            local parts
+            parts=$(echo "$assets" | grep "^${target}\.part" | sort)
+
+            # Download each part with resume support
+            local all_parts_ok=true
+            while read -r part; do
+                local part_file="$IMAGES_DIR/$part"
+                if [[ -f "$part_file" && "$overwrite" != "true" ]]; then
+                    echo "    Skipping $part (exists)"
+                else
+                    echo "    Downloading $part..."
+                    if ! gh release download "$version" --repo "homestak-dev/packer" \
+                        --pattern "$part" --dir "$IMAGES_DIR" --clobber 2>/dev/null; then
+                        # Try curl with resume
+                        local url
+                        url=$(gh release view "$version" --repo "homestak-dev/packer" \
+                            --json assets --jq ".assets[] | select(.name==\"$part\") | .url" 2>/dev/null)
+                        if [[ -n "$url" ]]; then
+                            curl -L -C - -o "$part_file" "$url" || all_parts_ok=false
+                        else
+                            all_parts_ok=false
+                        fi
+                    fi
+                fi
+            done <<< "$parts"
+
+            # Reassemble if all parts downloaded
+            if [[ "$all_parts_ok" == "true" ]]; then
+                echo "    Reassembling..."
+                cat "$IMAGES_DIR/${target}".part* > "$output_file" 2>/dev/null && \
+                    rm -f "$IMAGES_DIR/${target}".part*
+                echo "    Created: $output_file"
+            else
+                echo -e "${RED}    Failed to download all parts${NC}"
+            fi
+        elif echo "$assets" | grep -q "^${target}$"; then
+            echo "  Downloading $target..."
+            gh release download "$version" --repo "homestak-dev/packer" \
+                --pattern "$target" --dir "$IMAGES_DIR" --clobber 2>/dev/null || {
+                # Fallback to curl with resume
+                local url
+                url=$(gh release view "$version" --repo "homestak-dev/packer" \
+                    --json assets --jq ".assets[] | select(.name==\"$target\") | .url" 2>/dev/null)
+                if [[ -n "$url" ]]; then
+                    curl -L -C - -o "$output_file" "$url"
+                fi
+            }
+            echo "    Downloaded: $output_file"
+        else
+            echo -e "${YELLOW}  Not found in release: $target${NC}"
+        fi
+
+        # Download checksum if available
+        local checksum="${target}.sha256"
+        if echo "$assets" | grep -q "^${checksum}$"; then
+            gh release download "$version" --repo "homestak-dev/packer" \
+                --pattern "$checksum" --dir "$IMAGES_DIR" --clobber 2>/dev/null || true
+        fi
+    done
+
+    echo ""
+    echo -e "${GREEN}==>${NC} Download complete"
+    echo "Images saved to: $IMAGES_DIR"
+
+    # Auto-publish if requested
+    if [[ "$publish" == "true" ]]; then
+        echo ""
+        images_publish "${targets[@]}" $(if [[ "$overwrite" == "true" ]]; then echo "--overwrite"; fi)
+    fi
+}
+
+images_publish() {
+    local overwrite=false
+    local targets=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --overwrite) overwrite=true; shift ;;
+            -*) echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+            *) targets+=("$1"); shift ;;
+        esac
+    done
+
+    if [[ ${#targets[@]} -eq 0 ]]; then
+        # Publish all downloaded images
+        targets=($(ls "$IMAGES_DIR"/*.qcow2 2>/dev/null | xargs -I{} basename {} || true))
+    fi
+
+    if [[ ${#targets[@]} -eq 0 ]]; then
+        echo "No images to publish. Run: homestak images download all"
+        exit 1
+    fi
+
+    # Check if PVE storage exists
+    if [[ ! -d "$PVE_ISO_DIR" ]]; then
+        echo -e "${RED}PVE storage not found: $PVE_ISO_DIR${NC}"
+        echo "Is Proxmox VE installed?"
+        exit 1
+    fi
+
+    echo -e "${GREEN}==>${NC} Publishing images to PVE storage"
+
+    for target in "${targets[@]}"; do
+        # Normalize target name
+        if [[ ! "$target" =~ \.qcow2$ ]]; then
+            target="${target}.qcow2"
+        fi
+
+        local source_file="$IMAGES_DIR/$target"
+        # Convert .qcow2 to .img for PVE
+        local dest_name="${target%.qcow2}.img"
+        local dest_file="$PVE_ISO_DIR/$dest_name"
+
+        if [[ ! -f "$source_file" ]]; then
+            echo -e "${YELLOW}  Not found: $source_file${NC}"
+            continue
+        fi
+
+        if [[ -f "$dest_file" && "$overwrite" != "true" ]]; then
+            echo -e "${RED}  Exists: $dest_file${NC}"
+            echo "  Use --overwrite to replace"
+            continue
+        fi
+
+        echo "  Publishing $target -> $dest_name"
+        mv "$source_file" "$dest_file"
+        echo "    Installed: $dest_file"
+    done
+
+    echo ""
+    echo -e "${GREEN}==>${NC} Publish complete"
+}
+
 # Main
 [[ $# -lt 1 ]] && usage
 
@@ -302,6 +648,20 @@ CMD="$1"
 shift
 
 case "$CMD" in
+    site-init)
+        site_init "$@"
+        ;;
+    images)
+        [[ $# -lt 1 ]] && { echo "Usage: homestak images <list|download|publish> [args]"; exit 1; }
+        SUBCMD="$1"
+        shift
+        case "$SUBCMD" in
+            list) images_list "$@" ;;
+            download) images_download "$@" ;;
+            publish) images_publish "$@" ;;
+            *) echo -e "${RED}Unknown images subcommand: $SUBCMD${NC}"; exit 1 ;;
+        esac
+        ;;
     playbook)
         [[ $# -lt 1 ]] && { echo "Usage: homestak playbook <name> [args]"; exit 1; }
         run_playbook "$@"


### PR DESCRIPTION
## Summary

- Add `homestak site-init` command for site configuration initialization (#10)
- Add `homestak images` command for packer image management (#11)

## Test plan

- [ ] Test `homestak site-init` generates host config
- [ ] Test `homestak site-init --force` overwrites existing configs
- [ ] Test `homestak images list` shows available images
- [ ] Test `homestak images download debian-12-custom --publish` downloads and installs

Closes #10, closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)