### PR TITLE
Fix bats test assertions to match current help text format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+- Fix bats test assertions to match current help text format (#26)
+- Remove obsolete legacy path test (legacy support removed in v0.26)
+
 ## v0.37 - 2026-01-20
 
 ### Theme: Source-Agnostic Bootstrap

--- a/tests/homestak.bats
+++ b/tests/homestak.bats
@@ -44,14 +44,14 @@ load_functions() {
 @test "homestak --help shows usage" {
     run "$HOMESTAK_SH" --help
     [ "$status" -eq 1 ]  # usage exits with 1
-    [[ "$output" =~ "Homestak CLI" ]]
+    [[ "$output" =~ "homestak" ]]
     [[ "$output" =~ "Usage:" ]]
 }
 
 @test "homestak help shows usage" {
     run "$HOMESTAK_SH" help
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Homestak CLI" ]]
+    [[ "$output" =~ "homestak" ]]
 }
 
 @test "homestak with no args shows usage" {
@@ -76,11 +76,6 @@ load_functions() {
 
     run grep "HOMESTAK_ETC=" "$HOMESTAK_SH"
     [[ "$output" =~ '/usr/local/etc/homestak' ]]
-}
-
-@test "Legacy fallback path is defined" {
-    run grep -A5 "Legacy path support" "$HOMESTAK_SH"
-    [[ "$output" =~ '/opt/homestak' ]]
 }
 
 #


### PR DESCRIPTION
## Summary
- Update tests 2 and 3 to match `"homestak"` instead of `"Homestak CLI"`
- Remove test 7 (legacy path test) - legacy support removed in v0.26

## Test plan
- [x] `make test` passes (19/19 tests)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)