### PR TITLE
fix(install): Enable site-config clone for HTTP sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+- Fix site-config clone for HTTP sources (iac-driver#116)
+  - Changed SKIP_SITE_CONFIG from true to false for HTTP sources
+  - site-config is now cloned; secrets are copied separately by iac-driver
+- Add DEBIAN_FRONTEND=noninteractive for apt-get in non-TTY environments
+
 ## v0.38 - 2026-01-21
 
 ### Fixed

--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,7 @@ detect_source() {
             SOURCE_TYPE="http"
             BASE_URL="$source"
             REF="${HOMESTAK_REF:-}"
-            SKIP_SITE_CONFIG=true  # Ansible handles secrets separately
+            SKIP_SITE_CONFIG=false  # Clone site-config (secrets copied separately)
 
             # Validate HTTP source requirements
             if [[ -z "$REF" ]]; then
@@ -219,6 +219,7 @@ log_info "Ref: $REF"
 # Step 1: Install minimal prerequisites
 #
 log_info "Installing prerequisites (git, make)..."
+export DEBIAN_FRONTEND=noninteractive  # Prevent debconf prompts in non-TTY environments
 apt-get update -qq
 apt-get install -y -qq git make > /dev/null
 


### PR DESCRIPTION
## Summary

Fix site-config handling for HTTP bootstrap sources to support recursive-pve scenarios with serve-repos.

## Type of Change
- [x] Bug fix

## Changes

- Changed `SKIP_SITE_CONFIG` from `true` to `false` for HTTP sources
  - site-config is now cloned from the HTTP server
  - Secrets are copied separately by iac-driver's CopySecretsAction
- Add `DEBIAN_FRONTEND=noninteractive` for apt-get in non-TTY environments

## Testing

Validated via iac-driver recursive-pve-roundtrip scenario with serve-repos.

## Related Issues

Related: iac-driver#116

## PR Readiness Checklist

- [x] Feature tested end-to-end (recursive-pve-roundtrip)
- [x] CHANGELOG entry in this PR